### PR TITLE
fix-deployment-workflow - wrap mup.js content in single quotes instead of double quotes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm i -g mup
 
       - name: Write mup.js content to file
-        run: echo '${{ secrets.MUP_JS_CONTENT }}' > ./mup.js
+        run: echo "${{ secrets.MUP_JS_CONTENT }}" > ./mup.js
         shell: bash
         working-directory: ./app/.deploy
 


### PR DESCRIPTION
[https://github.com/gameboiss/ask-me/blob/main/.github/pull_request_template.md]: #

# PR Description

- Changed `'${{ secrets.MUP_JS_CONTENT }}'` to `"${{ secrets.MUP_JS_CONTENT }}"`
  - Single quotes were conflicting with the single quotes used in the file
  - Single quotes are kept for `'${{ secrets.SETTINGS_JSON_CONTENT }}'` because it contains double quotes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Context or Relevant Issues

**Keep branch**
