### PR TITLE
159 add confirmation text when file is uploaded

### DIFF
--- a/app/client/scss/components/_file-upload.scss
+++ b/app/client/scss/components/_file-upload.scss
@@ -3,4 +3,14 @@
   border: 1px solid $theme-dark;
   border-radius: 6px;
   padding: 1rem;
+
+  .confirm-msg {
+    color: green;
+    opacity: 1;
+
+    &.hide {
+      transition: opacity 1s;
+      opacity: 0;
+    }
+  }
 }

--- a/app/imports/ui/components/FileUpload.jsx
+++ b/app/imports/ui/components/FileUpload.jsx
@@ -53,6 +53,7 @@ import { insertFileToFilesCollection, verifyFileType } from '../../../lib/files'
  */
 const FileUpload = ({ fc, label, accept, buttonVariant, customButton, onUpload }) => {
   const [inputFile, setInputFile] = useState(null);
+  const [showConfirmMsg, setShowConfirmMsg] = useState();
   const [alertMsg, setAlertMsg] = useState();
   const [showAlert, setShowAlert] = useState(false);
 
@@ -83,7 +84,11 @@ const FileUpload = ({ fc, label, accept, buttonVariant, customButton, onUpload }
     }
     try {
       const fileObj = await insertFileToFilesCollection(fc, inputFile);
+      setShowConfirmMsg(true);
       onUpload?.(fileObj);
+      setTimeout(() => {
+        setShowConfirmMsg();
+      }, 2000);
     } catch (err) {
       alert(`There was a problem while uploading file ${inputFile.name}`);
     }
@@ -96,23 +101,19 @@ const FileUpload = ({ fc, label, accept, buttonVariant, customButton, onUpload }
           {label}
           <OverlayTrigger
             placement="bottom"
-            overlay={inputFile?.type.startsWith('image') ? (
-              <Popover>
-                <Popover.Body>
-                  <Image
-                    alt="preview"
-                    src={URL.createObjectURL(inputFile)}
-                    width={100}
-                  />
-                </Popover.Body>
-              </Popover>
-            ) : <div />}
+            overlay={
+              inputFile?.type.startsWith('image') ? (
+                <Popover>
+                  <Popover.Body>
+                    <Image alt="preview" src={URL.createObjectURL(inputFile)} width={100} />
+                  </Popover.Body>
+                </Popover>
+              ) : (
+                <div />
+              )
+            }
           >
-            <Form.Control
-              type="file"
-              accept={accept}
-              onChange={handleChangeFile}
-            />
+            <Form.Control type="file" accept={accept} onChange={handleChangeFile} />
           </OverlayTrigger>
         </Form.Label>
       </Form.Group>
@@ -121,7 +122,14 @@ const FileUpload = ({ fc, label, accept, buttonVariant, customButton, onUpload }
           {alertMsg}
         </Alert>
       )}
-      <Button variant={buttonVariant} type="submit" onClick={handleUpload}>{customButton || 'Upload'}</Button>
+      <span>
+        <Button className="me-2" variant={buttonVariant} type="submit" onClick={handleUpload}>
+          {customButton || 'Upload'}
+        </Button>
+        <span className={showConfirmMsg ? 'confirm-msg' : 'confirm-msg hide'}>
+          File was uploaded!
+        </span>
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
[https://github.com/gameboiss/ask-me/blob/main/.github/pull_request_template.md]: #

# PR Description

- Added a confirmation message that shows up when a file is uploaded successfully
- It fades after 2 seconds

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Context or Relevant Issues

Please include additional context.

### [Issue Link](https://github.com/uhmanoalink/manoa-link/issues/159)
